### PR TITLE
Add URLPARAM environment variable to change the url query parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ Set the `PORT` environment variable to an available port (for example, 9009; the
 $ PORT=9009 node index.js
 ```
 
+Set the `URLPARAM` environment variable to change the `url` query parameter to another one (for example, `__target`; the default is `url`), and run cors-it with
+```
+$ URLPARAM=__target PORT=9009 node index.js
+```
+
 ### Build using Docker
 
 To build cors-it using a docker container:

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var app = require('express')();
 var request = require('request');
 var port = process.env.PORT || 3000;
+var urlparam = process.env.URLPARAM || 'url';
 
 app.use(function (req, res, next) {
 	var data='';
@@ -26,9 +27,9 @@ app.options('*', function (req, res) {
 });
 
 app.use(function (req, res, next) {
-	if (req.query.url) {
+	if (req.query[urlparam]) {
 		var options = {
-			url: req.query.url,
+			url: req.query[urlparam],
 			method: req.method,
 			headers: req.headers,
 			qs: req.query
@@ -36,7 +37,7 @@ app.use(function (req, res, next) {
 		if (['PUT', 'POST', 'PATCH'].indexOf(req.method) > -1) {
 			options.body = req.body;
 		}
-		delete options.qs.url;
+		delete options.qs[urlparam];
 		delete options.headers.host;
 		delete options.headers.origin;
 		request(options)


### PR DESCRIPTION
CORS target url may use the `url` as query parameter.
In such case, change the name of `url` query parameter is required.