### PR TITLE
If Access-Control-Request-Headers is specified in request, copy it to Access-Control-Response-Headers in response

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,10 @@ app.use(function (req, res, next) {
 
 app.use(function (req, res, next) {
 	res.header('Access-Control-Allow-Origin', '*');
-	res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
+	if(req.header()) {
+	} else {
+		res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
+	}
 	next();
 });
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ app.use(function (req, res, next) {
 
 app.use(function (req, res, next) {
 	res.header('Access-Control-Allow-Origin', '*');
-	if(req.header()) {
+	if(req.header('Access-Control-Allow-Headers')) {
 	} else {
 		res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
 	}


### PR DESCRIPTION
If Access-Control-Request-Headers is specified in request, copy it to Access-Control-Response-Headers in response
